### PR TITLE
fix: appstore cannot connect 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ import { NativeMarket } from "@capgo/native-market";
  * @returns void
  */
 NativeMarket.openStoreListing({
-  appId: "com.example.app",
+  appStoreId: 1234567,
+  playStoreId: "com.example.app"
 });
 
 /**
@@ -110,14 +111,14 @@ NativeMarket.search({
 ### openStoreListing(...)
 
 ```typescript
-openStoreListing(options: { appId: string; }) => Promise<void>
+openStoreListing(options: { appStoreId: number, playStoreId: string; }) => Promise<void>
 ```
 
 This method will launch link in Play/App Store.
 
-| Param         | Type                            |
-| ------------- | ------------------------------- |
-| **`options`** | <code>{ appId: string; }</code> |
+| Param         | Type                                                      |
+| ------------- |-----------------------------------------------------------|
+| **`options`** | <code>{ appStoreId: number, playStoreId: string; }</code> |
 
 **Since:** 1.0.0
 

--- a/android/src/main/java/com/getcapacitor/community/nativemarket/NativeMarket.java
+++ b/android/src/main/java/com/getcapacitor/community/nativemarket/NativeMarket.java
@@ -15,8 +15,8 @@ public class NativeMarket extends Plugin {
   @PluginMethod
   public void openStoreListing(PluginCall call) {
     try {
-      if (call.hasOption("appId")) {
-        String appId = call.getString("appId");
+      if (call.hasOption("playStoreId")) {
+        String appId = call.getString("playStoreId");
 
         Context context = this.bridge.getActivity().getApplicationContext();
         Intent intent = new Intent(
@@ -28,7 +28,7 @@ public class NativeMarket extends Plugin {
 
         call.resolve();
       } else {
-        call.reject("appId is missing");
+        call.reject("playStoreId is missing");
       }
     } catch (Exception ex) {
       call.error(ex.getLocalizedMessage());

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -9,8 +9,8 @@ import Capacitor
 public class NativeMarket: CAPPlugin {
     
     @objc func openStoreListing(_ call: CAPPluginCall) {
-        if call.hasOption("appId") {
-            let appId = call.getString("appId")
+        if call.hasOption("appStoreId") {
+            let appId = call.getString("appStoreId")
             
             let url = "itms-apps://itunes.apple.com/app/" + appId!
             let appUrl = URL(string: url)
@@ -28,7 +28,7 @@ public class NativeMarket: CAPPlugin {
                 }
             }
         } else {
-            call.reject("appId is missing")
+            call.reject("appStoreId is missing")
         }
     }
     

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -8,7 +8,7 @@ export interface NativeMarketPlugin {
    *
    * @since 1.0.0
    */
-  openStoreListing(options: { appId: string }): Promise<void>;
+  openStoreListing(options: { appStoreId: number, playStoreId: string }): Promise<void>;
   /**
    * This method will deep-link directly to an Play/App store listing page.
    *

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,7 @@ import { WebPlugin } from "@capacitor/core";
 import { NativeMarketPlugin } from "./definitions";
 
 export class NativeMarketWeb extends WebPlugin implements NativeMarketPlugin {
-  openStoreListing(_options: { appId: string }): Promise<void> {
+  openStoreListing(_options: { appStoreId: number , playStoreId : string }): Promise<void> {
     throw new Error("Method not implemented.");
   }
 


### PR DESCRIPTION
I think we can no longer open the app on appstore by its bundle id. but we can use the store id 

example: 
https://apps.apple.com/us/app/appname/id1234567

passing 1234567 would work 